### PR TITLE
Fix PhpUnit not running tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_script:
   - php bin/console faker:populate --env=test
 
 script:
-  - phpunit
+  - ./vendor/bin/phpunit


### PR DESCRIPTION
The PHP7 image on Travis uses the global Phpunit by default, which is v6.2.2. This PR forces the use of the local installed Phpunit defined in the composer.json file.